### PR TITLE
Copy teleport command uses minecraft:tp now

### DIFF
--- a/src/components/MainMap.vue
+++ b/src/components/MainMap.vue
@@ -117,7 +117,7 @@ onMounted(() => {
 
     map.addEventListener("contextmenu", async (evt: L.LeafletMouseEvent) => {
         const pos = getPosition(map, evt.latlng)
-        navigator.clipboard.writeText(`/execute in ${settingsStore.dimension.toString()} run tp @s ${pos[0].toFixed(0)} ${(pos[1] + (project_down.value ? 10 : 0)).toFixed(0)} ${pos[2].toFixed()}`)
+        navigator.clipboard.writeText(`/execute in ${settingsStore.dimension.toString()} run minecraft:tp @s ${pos[0].toFixed(0)} ${(pos[1] + (project_down.value ? 10 : 0)).toFixed(0)} ${pos[2].toFixed()}`)
         show_info.value = true
         setTimeout(() => show_info.value = false, 2000)
     })


### PR DESCRIPTION
Fixes issues like having the default /tp command overriden by one which doesnt support @s (EssentialsX)